### PR TITLE
Put correct links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Replace `<YOUR-API-KEY>` with the API Key created in step 1. Alternatively inste
 
 ### 1. API Key
 
-First, go to to [CloudGlue API Portal](https://app.cloudglue.dev/home/api-keys) to create an API Key. This will be used to authenticate the MCP server with your CloudGlue account.
+First, get a CloudGlue API Key from [cloudglue.dev](http://cloudglue.dev), this will be used to authenticate the MCP server with your CloudGlue account.
 
 ### 2. Install and build server locally
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-mcp-server",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aviaryhq/cloudglue-js": "^0.0.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
   "type": "module",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "index.js",
   "bin": {
     "cloudglue-mcp-server": "build/index.js"


### PR DESCRIPTION
fixed one link earlier to the longer term location folks should look for API keys, missed this one. Updating README and bumping package again to update docs in npm.