### PR TITLE
surface only completed files / select fields to output for collections and videos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-mcp-server",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aviaryhq/cloudglue-js": "^0.0.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
   "type": "module",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "index.js",
   "bin": {
     "cloudglue-mcp-server": "build/index.js"

--- a/src/tools/get-video-info.ts
+++ b/src/tools/get-video-info.ts
@@ -17,11 +17,36 @@ export function registerGetVideoInfo(server: McpServer, cgClient: CloudGlue) {
     schema,
     async ({ file_id }) => {
       const file = await cgClient.files.getFile(file_id);
+
+      if (file.status !== "completed") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Unable to retrieve video: Video is in ${file.status} status`,
+            },
+          ],
+          isError: true
+        };
+      }
+
+      const videoInfo = {
+        filename: file.filename,
+        uri: file.uri,
+        id: file.id,
+        created_at: file.created_at,
+        metadata: file.metadata,
+        video_info: file.video_info ? {
+          duration_seconds: file.video_info.duration_seconds,
+          has_audio: file.video_info.has_audio
+        } : null
+      };
+
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(file),
+            text: JSON.stringify(videoInfo),
           },
         ],
       };

--- a/src/tools/list-collection-videos.ts
+++ b/src/tools/list-collection-videos.ts
@@ -28,11 +28,34 @@ export function registerListCollectionVideos(
       const files = await cgClient.collections.listVideos(collection_id, {
         limit: limit,
       });
+
+      // Process each file to get additional information
+      const processedFiles = await Promise.all(
+        files.data
+          .filter(file => file.status === "completed")
+          .map(async (file) => {
+            const fileInfo = await cgClient.files.getFile(file.file_id);
+            
+            return {
+              file_id: file.file_id,
+              collection_id: file.collection_id,
+              filename: fileInfo.filename,
+              uri: fileInfo.uri,
+              added_at: file.added_at,
+              metadata: fileInfo.metadata,
+              video_info: fileInfo.video_info ? {
+                duration_seconds: fileInfo.video_info.duration_seconds,
+                has_audio: fileInfo.video_info.has_audio
+              } : null
+            };
+          })
+      );
+
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(files),
+            text: JSON.stringify(processedFiles),
           },
         ],
       };

--- a/src/tools/list-video-collections.ts
+++ b/src/tools/list-video-collections.ts
@@ -23,11 +23,45 @@ export function registerListVideoCollections(
       const collections = await cgClient.collections.listCollections({
         limit: limit,
       });
+
+      // Process each collection to get video counts and selective fields
+      const processedCollections = await Promise.all(
+        collections.data.map(async (collection) => {
+          // Get all videos in the collection to count completed ones
+          const videos = await cgClient.collections.listVideos(collection.id, {
+            limit: 100, // TODO paginate
+          });
+          
+          const completedVideoCount = videos.data.filter(
+            video => video.status === "completed"
+          ).length;
+
+          return {
+            id: collection.id,
+            name: collection.name,
+            created_at: collection.created_at,
+            video_count: completedVideoCount,
+            ...(collection.description && { description: collection.description }),
+            ...(collection.extract_config && {
+              extract_config: {
+                ...(collection.extract_config.prompt && { prompt: collection.extract_config.prompt }),
+                ...(collection.extract_config.schema && { schema: collection.extract_config.schema })
+              }
+            })
+          };
+        })
+      );
+
+      // Filter out collections with no completed videos
+      const collectionsWithVideos = processedCollections.filter(
+        collection => collection.video_count > 0
+      );
+
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(collections),
+            text: JSON.stringify(collectionsWithVideos),
           },
         ],
       };

--- a/src/tools/list-video-collections.ts
+++ b/src/tools/list-video-collections.ts
@@ -41,13 +41,11 @@ export function registerListVideoCollections(
             name: collection.name,
             created_at: collection.created_at,
             video_count: completedVideoCount,
-            ...(collection.description && { description: collection.description }),
-            ...(collection.extract_config && {
-              extract_config: {
-                ...(collection.extract_config.prompt && { prompt: collection.extract_config.prompt }),
-                ...(collection.extract_config.schema && { schema: collection.extract_config.schema })
-              }
-            })
+            description: collection.description ?? undefined,
+            extract_config: collection.extract_config ? {
+              prompt: collection.extract_config.prompt ?? undefined,
+              schema: collection.extract_config.schema ?? undefined
+            } : undefined
           };
         })
       );

--- a/src/tools/list-videos.ts
+++ b/src/tools/list-videos.ts
@@ -18,11 +18,26 @@ export function registerListVideos(server: McpServer, cgClient: CloudGlue) {
     schema,
     async ({ limit }) => {
       const files = await cgClient.files.listFiles({ limit: limit });
+      
+      const filteredFiles = files.data
+        .filter(file => file.status === "completed")
+        .map(file => ({
+          filename: file.filename,
+          uri: file.uri,
+          id: file.id,
+          created_at: file.created_at,
+          metadata: file.metadata,
+          video_info: file.video_info ? {
+            duration_seconds: file.video_info.duration_seconds,
+            has_audio: file.video_info.has_audio
+          } : null
+        }));
+
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(files),
+            text: JSON.stringify(filteredFiles),
           },
         ],
       };


### PR DESCRIPTION
cleaning up output for MCP tools by:
- listing most relevant file/video infos and not just posting everything
- only displaying completed files (not pending or failed items)
- filtering out collections from list with 0 completed videos
- selecting most relevant metadata when listing collections

also bumps package-lock/package.json to newer version