### PR TITLE
Updating tool descriptions to work with new APIs, adding 2 new tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-mcp-server",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Elastic-2.0",
       "dependencies": {
-        "@aviaryhq/cloudglue-js": "^0.0.12",
+        "@aviaryhq/cloudglue-js": "github:aviaryhq/cloudglue-js#ac1c3760b323ca561657895ef0cd4347e5e190e7",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "dotenv": "^16.4.7",
         "shx": "^0.4.0",
@@ -25,9 +25,9 @@
       }
     },
     "node_modules/@aviaryhq/cloudglue-js": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@aviaryhq/cloudglue-js/-/cloudglue-js-0.0.12.tgz",
-      "integrity": "sha512-89pcGYAifAOs/4oBcgozpZZCk601iNnO6bfhAVc65zDnGCri/6vyrgHZ37CuMtLrOTQ4KG7ix4D6N67l762DZA==",
+      "version": "0.0.13",
+      "resolved": "git+ssh://git@github.com/aviaryhq/cloudglue-js.git#ac1c3760b323ca561657895ef0cd4347e5e190e7",
+      "integrity": "sha512-zUhNMr6swVoRt03u1E2Ifxd7LtS50+LJyU9d0Ndo/V0CD8FDJvDNbcKOwDbIfqJI6qmmauSzuvm7VDaG2GIF2Q==",
       "license": "Elastic-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.9",
       "license": "Elastic-2.0",
       "dependencies": {
-        "@aviaryhq/cloudglue-js": "github:aviaryhq/cloudglue-js#ac1c3760b323ca561657895ef0cd4347e5e190e7",
+        "@aviaryhq/cloudglue-js": "^0.0.13",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "dotenv": "^16.4.7",
         "shx": "^0.4.0",
@@ -26,8 +26,8 @@
     },
     "node_modules/@aviaryhq/cloudglue-js": {
       "version": "0.0.13",
-      "resolved": "git+ssh://git@github.com/aviaryhq/cloudglue-js.git#ac1c3760b323ca561657895ef0cd4347e5e190e7",
-      "integrity": "sha512-zUhNMr6swVoRt03u1E2Ifxd7LtS50+LJyU9d0Ndo/V0CD8FDJvDNbcKOwDbIfqJI6qmmauSzuvm7VDaG2GIF2Q==",
+      "resolved": "https://registry.npmjs.org/@aviaryhq/cloudglue-js/-/cloudglue-js-0.0.13.tgz",
+      "integrity": "sha512-ezfB1IsOn6/LQ5Wxm89nwVeZD8qsPW1/bzLMKmvACzdui2PiqJpiblQMKph72v+doOMW/ZHeAisQuJHNAIGzXw==",
       "license": "Elastic-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
   "type": "module",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "index.js",
   "bin": {
     "cloudglue-mcp-server": "build/index.js"
@@ -24,7 +24,7 @@
   "license": "Elastic-2.0",
   "description": "CloudGlue MCP Server",
   "dependencies": {
-    "@aviaryhq/cloudglue-js": "^0.0.12",
+    "@aviaryhq/cloudglue-js": "github:aviaryhq/cloudglue-js#ac1c3760b323ca561657895ef0cd4347e5e190e7",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "dotenv": "^16.4.7",
     "shx": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "Elastic-2.0",
   "description": "CloudGlue MCP Server",
   "dependencies": {
-    "@aviaryhq/cloudglue-js": "github:aviaryhq/cloudglue-js#ac1c3760b323ca561657895ef0cd4347e5e190e7",
+    "@aviaryhq/cloudglue-js": "^0.0.13",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "dotenv": "^16.4.7",
     "shx": "^0.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,18 +10,23 @@ import { registerListVideoCollections } from "./tools/list-video-collections.js"
 import { registerGetVideoInfo } from "./tools/get-video-info.js";
 import { registerListVideos } from "./tools/list-videos.js";
 import { registerListCollectionVideos } from "./tools/list-collection-videos.js";
-import { registerGetCollectionVideoDescription } from "./tools/get-collection-video-description.js";
+import { registerGetCollectionRichTranscripts } from "./tools/get-collection-rich-transcripts.js";
 import { registerGetCollectionVideoEntities } from "./tools/get-collection-video-entities.js";
 import { registerDescribeCloudglueVideo } from "./tools/transcribe-cloudglue-video.js";
 import { registerDescribeYoutubeVideo } from "./tools/transcribe-youtube-video.js";
 import { registerExtractCloudglueVideoEntities } from "./tools/extract-cloudglue-video-entities.js";
 import { registerExtractYoutubeVideoEntities } from "./tools/extract-youtube-video-entities.js";
 import { registerChatWithVideoCollection } from "./tools/chat-with-video-collection.js";
+import { registerListTranscripts } from "./tools/list-transcripts.js";
+import { registerListExtracts } from "./tools/list-extracts.js";
 
 // Parse command line arguments
 const { values: args } = parseArgs({
   options: {
     "api-key": {
+      type: "string",
+    },
+    "base-url": {
       type: "string",
     },
   },
@@ -32,12 +37,15 @@ dotenv.config();
 
 const cgClient = new CloudGlue({
   apiKey: args["api-key"] || process.env.CLOUDGLUE_API_KEY,
+  ...(args["base-url"] || process.env.CLOUDGLUE_BASE_URL ? {
+    baseUrl: args["base-url"] || process.env.CLOUDGLUE_BASE_URL,
+  } : {}),
 });
 
 // Create server instance
 const server = new McpServer({
   name: "cloudglue-mcp-server",
-  version: "0.0.7",
+  version: "0.0.9",
   capabilities: {
     resources: {},
     tools: {},
@@ -49,14 +57,15 @@ registerListVideoCollections(server, cgClient);
 registerGetVideoInfo(server, cgClient);
 registerListVideos(server, cgClient);
 registerListCollectionVideos(server, cgClient);
-// TODO: migrate to new collection video transcribe API when available
-registerGetCollectionVideoDescription(server, cgClient);
+registerGetCollectionRichTranscripts(server, cgClient);
 registerGetCollectionVideoEntities(server, cgClient);
 registerDescribeCloudglueVideo(server, cgClient);
 registerDescribeYoutubeVideo(server, cgClient);
 registerExtractCloudglueVideoEntities(server, cgClient);
 registerExtractYoutubeVideoEntities(server, cgClient);
 registerChatWithVideoCollection(server, cgClient);
+registerListTranscripts(server, cgClient);
+registerListExtracts(server, cgClient);
 
 // Run server
 async function main() {

--- a/src/tools/chat-with-video-collection.ts
+++ b/src/tools/chat-with-video-collection.ts
@@ -6,7 +6,7 @@ export const schema = {
   collection_id: z
     .string()
     .describe(
-      "The collection id without the 'cloudglue://collections/' prefix (e.g., for 'cloudglue://collections/abc123', use 'abc123')",
+      "The collection id without the 'cloudglue://collections/' prefix (e.g., for 'cloudglue://collections/abc123', use 'abc123'. Only Rich Transcript (collection_type='rich-transcripts') and Entity (collection_type: 'entities') collections are supported as input to this tool.)",
     ),
   prompt: z
     .string()

--- a/src/tools/extract-cloudglue-video-entities.ts
+++ b/src/tools/extract-cloudglue-video-entities.ts
@@ -21,7 +21,7 @@ export function registerExtractCloudglueVideoEntities(
 ) {
   server.tool(
     "extract_cloudglue_video_entities",
-    "Returns detailed entities extracted from a video uploaded to CloudGlue. Don't use this tool if the video is already part of a collection; use get_collection_video_entities instead.",
+    "Returns detailed entities extracted from a video uploaded to CloudGlue. Don't use this tool if the video is already part of an entity collection; use get_collection_video_entities instead.",
     schema,
     async ({ url, prompt }) => {
       const extractJob = await cgClient.extract.createExtract(url, {

--- a/src/tools/extract-youtube-video-entities.ts
+++ b/src/tools/extract-youtube-video-entities.ts
@@ -21,7 +21,7 @@ export function registerExtractYoutubeVideoEntities(
 ) {
   server.tool(
     "extract_youtube_video_entities",
-    "Returns detailed entities extracted from a youtube video. Don't use this tool if the video is already part of a collection; use get_collection_video_entities instead.  Note that YouTube videos are currently limited to speech and metadata level understanding, for fully fledge multimodal video understanding please upload a file instead to the CloudGlue Files API and use the extract_cloudglue_video_entities tool.",
+    "Returns detailed entities extracted from a youtube video. Don't use this tool if the video is already part of an entity collection; use get_collection_video_entities instead.  Note that YouTube videos are currently limited to speech and metadata level understanding, for fully fledge multimodal video understanding please upload a file instead to the CloudGlue Files API and use the extract_cloudglue_video_entities tool.",
     schema,
     async ({ url, prompt }) => {
       const extractJob = await cgClient.extract.createExtract(url, {

--- a/src/tools/get-collection-rich-transcripts.ts
+++ b/src/tools/get-collection-rich-transcripts.ts
@@ -15,24 +15,23 @@ export const schema = {
     ),
 };
 
-export function registerGetCollectionVideoDescription(
+export function registerGetCollectionRichTranscripts(
   server: McpServer,
   cgClient: CloudGlue,
 ) {
   server.tool(
-    "get_collection_video_description",
-    "Returns detailed description of a video in a given collection. Requires both collection_id and file_id parameters without their URI prefixes",
+    "get_collection_rich_transcripts",
+    "Returns rich transcripts of a video in a given collection. Requires both collection_id and file_id parameters without their URI prefixes",
     schema,
     async ({ collection_id, file_id }) => {
-      const description = await cgClient.collections.getDescription(
-        collection_id,
-        file_id,
+      const transcripts = await cgClient.collections.getTranscripts(
+        collection_id, file_id, undefined, undefined, 'markdown'
       );
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(description),
+            text: transcripts.content ?? "No transcripts found",
           },
         ],
       };

--- a/src/tools/get-collection-video-entities.ts
+++ b/src/tools/get-collection-video-entities.ts
@@ -21,7 +21,7 @@ export function registerGetCollectionVideoEntities(
 ) {
   server.tool(
     "get_collection_video_entities",
-    "Returns detailed entities extracted from a video in a given collection. Requires both collection_id and file_id parameters without their URI prefixes",
+    "Returns detailed entities extracted from a video in a given entity collection. Requires both collection_id and file_id parameters without their URI prefixes",
     schema,
     async ({ collection_id, file_id }) => {
       const entities = await cgClient.collections.getEntities(

--- a/src/tools/list-extracts.ts
+++ b/src/tools/list-extracts.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { CloudGlue } from "@aviaryhq/cloudglue-js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export const schema = {
+  limit: z
+    .number()
+    .min(1)
+    .max(100)
+    .describe("The maximum number of videos to return")
+    .default(10),
+  url: z
+    .string()
+    .describe("The url of the video from which entities were extracted, either cloudglue or youtube urls")
+    .optional(),
+};
+
+export function registerListExtracts(server: McpServer, cgClient: CloudGlue) {
+  server.tool(
+    "list_extracts",
+    "Returns individual video entity extractions executed by user on independent of collections and optionally filtered by url",
+    schema,
+    async ({ limit, url }) => {
+      const extractions = await cgClient.extract.listExtracts({ limit: limit, status: 'completed', url: url });
+      
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(extractions),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/list-transcripts.ts
+++ b/src/tools/list-transcripts.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { CloudGlue } from "@aviaryhq/cloudglue-js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export const schema = {
+  limit: z
+    .number()
+    .min(1)
+    .max(100)
+    .describe("The maximum number of videos to return")
+    .default(10),
+  url: z
+    .string()
+    .describe("The url of the video from which entities were extracted, either cloudglue or youtube urls")
+    .optional(),
+};
+
+export function registerListTranscripts(server: McpServer, cgClient: CloudGlue) {
+  server.tool(
+    "list_transcripts",
+    "Returns individual video transcription jobs executed by user on independent of collections and optionally filtered by url",
+    schema,
+    async ({ limit, url }) => {
+      const transcripts = await cgClient.transcribe.listTranscribes({ limit: limit, status: 'completed', url: url });
+      
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(transcripts),
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
MCP server bump in version, with following updates
- Picks up recent SDK changes https://github.com/aviaryhq/cloudglue-js/pull/8
- Makes use of new transcribe APIs consistently / deletes old describe usage
- Adds two new tools: list_extracts, and list_transcribes that both optionally filter by url
- Adds collection_type filter to list_collections tool
- Adds some notes to various tools to give LLM hint when calling is applicable given the collection type of either rich transcript collections or the entity collections

![image](https://github.com/user-attachments/assets/5d9b2063-ac40-4e6d-81e4-3bf89d2feb3f)

Note: temporarily using non main branch version of cloudglue-js to test, will pin to actual npm package prior to merge