### PR TITLE
Update Github Action to not include timestamp in tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build & Release (MCP)
+name: Build & Release Claude Desktop Extension
 
 on:
   push:
@@ -39,13 +39,9 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Generate timestamp
-        id: ts
-        run: echo "ts=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_OUTPUT"
-
       - name: Compose tag
         id: ver
-        run: echo "tag=v${{ steps.pkg.outputs.version }}+${{ steps.ts.outputs.ts }}" >> "$GITHUB_OUTPUT"
+        run: echo "tag=v${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: SHA256 checksum
         run: sha256sum cloudglue-mcp-server.mcpb > SHA256SUMS.txt

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "@aviaryhq/cloudglue-mcp-server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Cloudglue MCP Server",
   "icon": "assets/icon.png",
   "author": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "@aviaryhq/cloudglue-mcp-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Cloudglue MCP Server",
   "icon": "assets/icon.png",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-mcp-server",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Elastic-2.0",
       "dependencies": {
         "@aviaryhq/cloudglue-js": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
   "type": "module",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "index.js",
   "bin": {
     "cloudglue-mcp-server": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
   "type": "module",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "index.js",
   "bin": {
     "cloudglue-mcp-server": "build/index.js"


### PR DESCRIPTION
Make it so the Github action just uses the version from package.json when making a tag + release