### PR TITLE
apply security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-mcp-server",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@aviaryhq/cloudglue-js": "^0.4.0",
@@ -470,7 +470,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
       "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -930,7 +929,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1683,16 +1681,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -2232,16 +2220,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -2404,7 +2389,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "index.js",
   "bin": {
     "cloudglue-mcp-server": "build/index.js"
@@ -35,5 +35,8 @@
     "@types/node": "^22.14.1",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "tmp": "^0.2.4"
   }
 }


### PR DESCRIPTION
# Security Fix: tmp Package Vulnerability

## Issue

A security vulnerability (CVE-2025-54798) was identified in the `tmp` package version 0.0.33, which allows arbitrary temporary file/directory writes via symbolic link manipulation in the `dir` parameter. This vulnerability affects versions <= 0.2.3, with the patched version being 0.2.4+.

https://github.com/aviaryhq/cloudglue-mcp-server/security/dependabot/3

## Root Cause

The vulnerable `tmp@0.0.33` package was introduced as a transitive dependency through:
- `@anthropic-ai/mcpb@1.1.1` → `@inquirer/editor@3.0.1` → `external-editor@3.1.0` → `tmp@^0.0.33`

Since `external-editor@3.1.0` requires `tmp@^0.0.33`, Dependabot was unable to automatically update to the patched version.

## Solution

Added an `overrides` field to `package.json` to force all instances of `tmp` to use the patched version `^0.2.4`, regardless of what the dependency tree specifies:

```json
"overrides": {
  "tmp": "^0.2.4"
}
```

This ensures that even though `external-editor@3.1.0` requires `tmp@^0.0.33`, npm will use `tmp@0.2.5` (the latest patched version) throughout the entire dependency tree.

## Verification

- ✅ `npm list tmp` confirms `tmp@0.2.5` is installed and marked as "overridden"
- ✅ `npm audit` reports 0 vulnerabilities
- ✅ Build completes successfully
- ✅ All functionality remains intact

## References

- [GitHub Advisory: GHSA-52f5-9888-hmc6](https://github.com/advisories/GHSA-52f5-9888-hmc6)
- [npm overrides documentation](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides)

