### PR TITLE
add tool annotations, link privacy policy in manifest, bundle update version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,14 @@
 {
   "manifest_version": "0.2",
   "name": "@aviaryhq/cloudglue-mcp-server",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Cloudglue MCP Server",
   "icon": "assets/icon.png",
   "author": {
     "name": "Aviary Inc."
   },
   "license": "MIT",
+  "privacy_policies": ["https://cloudglue.dev/privacy"],
   "server": {
     "type": "node",
     "entry_point": "build/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-mcp-server",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@aviaryhq/cloudglue-js": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aviaryhq/cloudglue-mcp-server",
   "type": "module",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "index.js",
   "bin": {
     "cloudglue-mcp-server": "build/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ const cgClient = new CloudGlue({
 // Create server instance
 const server = new McpServer({
   name: "cloudglue-mcp-server",
-  version: "0.2.2",
+  version: "0.2.3",
 });
 
 // Register all tools

--- a/src/tools/describe-video.ts
+++ b/src/tools/describe-video.ts
@@ -45,6 +45,12 @@ export function registerDescribeVideo(server: McpServer, cgClient: CloudGlue) {
     "describe_video",
     "Gets comprehensive video descriptions with intelligent cost optimization and pagination support. Automatically checks for existing descriptions before creating new ones. Supports YouTube URLs, Cloudglue URLs, and direct HTTP video URLs with different analysis levels. Results are paginated in 5-minute segments - use the 'page' parameter to retrieve specific time segments of longer videos (page 0 = first 5 minutes, page 1 = next 5 minutes, etc.). Use 'start_time_seconds' to begin pagination from a specific time index (defaults to 0 for start of video). The combination of start_time_seconds and page allows precise navigation: start_time_seconds sets the base offset, and page increments in 5-minute segments from that offset. When `collection_id` is provided (from a media-descriptions collection), this tool fetches previously extracted descriptions that were stored in that collection for the given Cloudglue file, saving time and cost. Use this for individual video analysis.",
     schema,
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ url, collection_id, page = 0, start_time_seconds = 0 }) => {
       const fileId = extractFileIdFromUrl(url);
       const PAGE_SIZE_SECONDS = 300; // 5 minutes in seconds

--- a/src/tools/extract-video-entities.ts
+++ b/src/tools/extract-video-entities.ts
@@ -45,6 +45,12 @@ export function registerExtractVideoEntities(
     "extract_video_entities",
     "Extract structured data and entities from videos with intelligent cost optimization and pagination support. Two modes: (1) Fetch existing entities from an entities collection by providing collection_id (prompt not required) - retrieves previously extracted entities stored in that collection for the given Cloudglue file, returns error if not found, (2) Extract new entities by providing prompt (collection_id optional) - automatically checks for existing extractions before creating new ones. Supports YouTube URLs, Cloudglue URLs, and direct HTTP video URLs. The quality of results depends heavily on your prompt specificity. Pagination is supported - use the 'page' parameter to retrieve specific pages of segment-level entities. Use this for individual video analysis.",
     schema,
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ url, prompt, collection_id, page = 0 }) => {
       // Validate that either collection_id or prompt is provided
       if (!collection_id && !prompt) {

--- a/src/tools/get-video-metadata.ts
+++ b/src/tools/get-video-metadata.ts
@@ -18,6 +18,12 @@ export function registerGetVideoMetadata(
     "get_video_metadata",
     "Get comprehensive technical metadata about a Cloudglue video file including duration, resolution, file size, processing status, and computed statistics. Use this when you need video specifications, file details, or processing information rather than content analysis. Different from content-focused tools like describe_video.",
     schema,
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ file_id }) => {
       try {
         const file = await cgClient.files.getFile(file_id);

--- a/src/tools/list-collections.ts
+++ b/src/tools/list-collections.ts
@@ -28,6 +28,12 @@ export function registerListCollections(
     "list_collections",
     "Discover available video collections and their basic metadata. Use this first to understand what video collections exist before using other collection-specific tools. Shows collection IDs needed for other tools, video counts, and collection types. For collections with type 'media-descriptions', use `describe_video` with the collection_id parameter to fetch previously extracted descriptions for a given Cloudglue file. For collections with type 'entities', use `extract_video_entities` with the collection_id parameter to fetch previously extracted entities for a given Cloudglue file. Results are paginated in 25 collections per page - use the 'page' parameter to retrieve specific pages (page 0 = first 25 collections, page 1 = next 25 collections, etc.). Each response includes `page` and `total_pages` fields.",
     schema,
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ page = 0, collection_type }) => {
       const COLLECTIONS_PER_PAGE = 25;
       const limit = COLLECTIONS_PER_PAGE;

--- a/src/tools/list-videos.ts
+++ b/src/tools/list-videos.ts
@@ -37,6 +37,12 @@ export function registerListVideos(server: McpServer, cgClient: CloudGlue) {
     "list_videos",
     "Browse and search video metadata with powerful filtering options. Use this to explore available videos, find specific content by date, or see what's in a collection. Returns essential video info like duration, filename, and IDs needed for other tools. Results are paginated in 25 videos per page - use the 'page' parameter to retrieve specific pages (page 0 = first 25 videos, page 1 = next 25 videos, etc.). Each response includes `page` and `total_pages` fields. Use date filtering to focus on specific time periods, then paginate within those results.",
     schema,
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ page = 0, collection_id, created_after, created_before }) => {
       const VIDEOS_PER_PAGE = 25;
       const limit = VIDEOS_PER_PAGE;

--- a/src/tools/retrieve-summaries.ts
+++ b/src/tools/retrieve-summaries.ts
@@ -39,6 +39,12 @@ export function registerRetrieveSummaries(
     "retrieve_summaries",
     "Bulk retrieve video summaries and titles from a collection to quickly understand its content and themes. Works with both rich-transcripts and media-descriptions collections. Use this as your first step when analyzing a collection - it's more efficient than retrieving full descriptions and helps you determine if you need more detailed information. Perfect for getting a high-level overview of what's in a collection, identifying common topics, or determining if a collection contains relevant content for a specific query. For single videos, use describe_video instead. For targeted content discovery, consider using search_video_summaries (for relevant videos) or search_video_moments (for specific segments) instead of browsing through all summaries. Results are paginated in 25 summaries per page - use the 'page' parameter to retrieve specific pages (page 0 = first 25 summaries, page 1 = next 25 summaries, etc.). Each response includes `page` and `total_pages` fields. For comprehensive collection analysis, paginate through all summaries by incrementing the `page` parameter.",
     schema,
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ collection_id, page = 0, created_after, created_before }) => {
       const SUMMARIES_PER_PAGE = 25;
       const limit = SUMMARIES_PER_PAGE;

--- a/src/tools/search-video-moments.ts
+++ b/src/tools/search-video-moments.ts
@@ -23,6 +23,12 @@ export function registerSearchVideoMoments(
     "search_video_moments",
     "AI-powered semantic search to find specific video segments within a collection. Uses Cloudglue's search API to locate relevant moments across speech, on-screen text, and visual descriptions. Returns structured search results with timestamps and metadata. Perfect for finding needle-in-haystack spoken and visual content, specific discussions, or thematic analysis.",
     schema,
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ collection_id, query }) => {
       try {
         const response = await cgClient.search.searchContent({

--- a/src/tools/search-video-summaries.ts
+++ b/src/tools/search-video-summaries.ts
@@ -23,6 +23,12 @@ export function registerSearchVideoSummaries(
     "search_video_summaries",
     "AI-powered semantic search to find relevant videos within a collection. Uses Cloudglue's search API to locate videos based on their content, summaries, and metadata. Works with rich-transcripts and media-descriptions collections. Returns structured search results with video information and relevance scores. Perfect for discovering videos by topic, theme, or content similarity.",
     schema,
+    {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ collection_id, query }) => {
       try {
         const response = await cgClient.search.searchContent({

--- a/src/tools/segment-video-camera-shots.ts
+++ b/src/tools/segment-video-camera-shots.ts
@@ -31,6 +31,12 @@ export function registerSegmentVideoCameraShots(
     "segment_video_camera_shots",
     "Segment videos into camera shots with intelligent cost optimization. Automatically checks for existing shot segmentation jobs before creating new ones. Returns timestamps and metadata for each camera shot detected. Supports Cloudglue URLs and direct HTTP video URLs. Note: YouTube URLs are not supported for segmentation.",
     schema,
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ url }) => {
       // Helper function to format error response
       const formatErrorResponse = (error: string) => {

--- a/src/tools/segment-video-chapters.ts
+++ b/src/tools/segment-video-chapters.ts
@@ -37,6 +37,12 @@ export function registerSegmentVideoChapters(
     "segment_video_chapters",
     "Segment videos into chapters with intelligent cost optimization. Automatically checks for existing chapter segmentation jobs before creating new ones. Returns timestamps and descriptions for each chapter detected. Supports all URL formats: Cloudglue URLs, YouTube URLs, public HTTP video URLs, and data connector URLs (Dropbox, Google Drive, Zoom).",
     schema,
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async ({ url, prompt }) => {
       // Helper function to format error response
       const formatErrorResponse = (error: string) => {


### PR DESCRIPTION
### Changes

**Privacy Policy**
- Added `privacy_policies` field to `manifest.json` pointing to https://cloudglue.dev/privacy

**Tool Annotations**
- Added MCP tool annotations to all 10 tools:
  - `readOnlyHint`: `true` for read-only tools (list, get, search, retrieve), `false` for tools that may create jobs
  - `destructiveHint`: `false` for all (no tools delete/modify existing data)
  - `idempotentHint`: `true` for all (repeated calls don't cause additional side effects)
  - `openWorldHint`: `true` for all (tools access external Cloudglue API)

**Version Bump**
- Updated version to `0.2.3` in `manifest.json`, `package.json`, and `src/index.ts`

