### PR TITLE
fix risk of supply chain compromise because dependencies can run arbi…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
…trary scripts

fixing issue identified from code security scanner:

By default, npm packages can run arbitrary preinstall, install, and postinstall "lifecycle" scripts. As a result, every npm install carries some risk of compromising a developer's machine. This has been a pervasive, recurring vector for supply chain attacks, such as the 2025 "Shai-Hulud 2.0" npm worm ([Wiz Research](https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack) / [Datadog Security Labs](https://securitylabs.datadoghq.com/articles/shai-hulud-2.0-npm-worm/)).

You can immunize yourself from script-based attacks by instructing npm not to run lifecycle scripts at npm install time. While every dependency still carries risk, this reduces the likelihood that a compromised dependency can execute before you discover it's been compromised.
