### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+
+<!-- 1–3 bullets: what changed and why. Link issues if relevant. -->
+
+## Test plan
+
+- [ ]
+- [ ]


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` with `Summary` and `Test plan` sections
- Mirrors the template added to `makeyolo/cloudglue` (#1113) for consistency across repos

## Test plan

- [ ] Merge, then open a fresh PR — confirm description prefills with `## Summary` and `## Test plan` headers
