### PR TITLE
Mark MCP tool failures as errors

### DIFF
--- a/src/tools/describe-video.ts
+++ b/src/tools/describe-video.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Cloudglue } from "@cloudglue/cloudglue-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getErrorMessage, jsonErrorResponse } from "./error-response.js";
 
 export const schema = {
   url: z
@@ -310,40 +311,18 @@ export function registerDescribeVideo(server: McpServer, cgClient: Cloudglue) {
           return formatPaginatedResponse(descriptionContent, page, totalPages);
         }
 
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  description:
-                    "Error: Failed to create description - job did not complete successfully",
-                  page: page,
-                  total_pages: 0,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return jsonErrorResponse({
+          description:
+            "Error: Failed to create description - job did not complete successfully",
+          page: page,
+          total_pages: 0,
+        });
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  description: `Error creating description: ${error instanceof Error ? error.message : "Unknown error"}`,
-                  page: page,
-                  total_pages: 0,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return jsonErrorResponse({
+          description: `Error creating description: ${getErrorMessage(error)}`,
+          page: page,
+          total_pages: 0,
+        });
       }
     },
   );

--- a/src/tools/error-response.ts
+++ b/src/tools/error-response.ts
@@ -1,0 +1,27 @@
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || error.name || "Unknown error";
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export function jsonErrorResponse(payload: Record<string, unknown>) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}

--- a/src/tools/extract-video-entities.ts
+++ b/src/tools/extract-video-entities.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Cloudglue } from "@cloudglue/cloudglue-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getErrorMessage, jsonErrorResponse } from "./error-response.js";
 
 export const schema = {
   url: z
@@ -54,30 +55,30 @@ export function registerExtractVideoEntities(
     async ({ url, prompt, collection_id, page = 0 }) => {
       // Validate that either collection_id or prompt is provided
       if (!collection_id && !prompt) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  video_level_entities: {},
-                  segment_level_entities: {
-                    entities: [],
-                    page: page,
-                    total_pages: 0,
-                  },
-                  error: "Either 'collection_id' or 'prompt' must be provided",
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return jsonErrorResponse({
+          video_level_entities: {},
+          segment_level_entities: {
+            entities: [],
+            page: page,
+            total_pages: 0,
+          },
+          error: "Either 'collection_id' or 'prompt' must be provided",
+        });
       }
 
       const fileId = extractFileIdFromUrl(url);
       const SEGMENTS_PER_PAGE = 25;
+
+      const formatEntityErrorResponse = (error: string) =>
+        jsonErrorResponse({
+          video_level_entities: {},
+          segment_level_entities: {
+            entities: [],
+            page: page,
+            total_pages: 0,
+          },
+          error,
+        });
 
       // Helper function to format paginated entity response
       const formatPaginatedEntityResponse = (
@@ -140,102 +141,32 @@ export function registerExtractVideoEntities(
             );
           } else {
             // Entities not found in collection
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify(
-                    {
-                      video_level_entities: {},
-                      segment_level_entities: {
-                        entities: [],
-                        page: page,
-                        total_pages: 0,
-                      },
-                      error: `No entities found for video in collection. The video may not have been processed yet or may not exist in the specified collection.`,
-                    },
-                    null,
-                    2,
-                  ),
-                },
-              ],
-            };
+            return formatEntityErrorResponse(
+              "No entities found for video in collection. The video may not have been processed yet or may not exist in the specified collection.",
+            );
           }
         } catch (error) {
           // Return error if collection lookup fails
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify(
-                  {
-                    video_level_entities: {},
-                    segment_level_entities: {
-                      entities: [],
-                      page: page,
-                      total_pages: 0,
-                    },
-                    error: `Error fetching entities from collection: ${error instanceof Error ? error.message : "Unknown error"}`,
-                  },
-                  null,
-                  2,
-                ),
-              },
-            ],
-          };
+          return formatEntityErrorResponse(
+            `Error fetching entities from collection: ${getErrorMessage(error)}`,
+          );
         }
       }
 
       // If collection_id was provided but fileId is missing, return error
       if (collection_id && !fileId) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  video_level_entities: {},
-                  segment_level_entities: {
-                    entities: [],
-                    page: page,
-                    total_pages: 0,
-                  },
-                  error:
-                    "collection_id requires a Cloudglue URL (cloudglue://files/file-id). Other URL formats are not supported for collection entity retrieval.",
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return formatEntityErrorResponse(
+          "collection_id requires a Cloudglue URL (cloudglue://files/file-id). Other URL formats are not supported for collection entity retrieval.",
+        );
       }
 
       // Step 2: Check for existing individual extracts for this URL with matching prompt
       // At this point, if collection_id was provided we would have already returned or errored
       // So prompt must be defined (validated at function start)
       if (!prompt) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  video_level_entities: {},
-                  segment_level_entities: {
-                    entities: [],
-                    page: page,
-                    total_pages: 0,
-                  },
-                  error:
-                    "prompt is required when collection_id is not provided",
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return formatEntityErrorResponse(
+          "prompt is required when collection_id is not provided",
+        );
       }
 
       // Step 2: Check for existing individual extracts for this URL with matching prompt
@@ -340,48 +271,13 @@ export function registerExtractVideoEntities(
           );
         }
 
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  video_level_entities: {},
-                  segment_level_entities: {
-                    entities: [],
-                    page: page,
-                    total_pages: 0,
-                  },
-                  error:
-                    "Failed to create entity extraction - job did not complete successfully",
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return formatEntityErrorResponse(
+          "Failed to create entity extraction - job did not complete successfully",
+        );
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  video_level_entities: {},
-                  segment_level_entities: {
-                    entities: [],
-                    page: page,
-                    total_pages: 0,
-                  },
-                  error: `Error creating entity extraction: ${error instanceof Error ? error.message : "Unknown error"}`,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return formatEntityErrorResponse(
+          `Error creating entity extraction: ${getErrorMessage(error)}`,
+        );
       }
     },
   );

--- a/src/tools/get-video-metadata.ts
+++ b/src/tools/get-video-metadata.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Cloudglue } from "@cloudglue/cloudglue-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getErrorMessage, jsonErrorResponse } from "./error-response.js";
 
 export const schema = {
   file_id: z
@@ -29,28 +30,17 @@ export function registerGetVideoMetadata(
         const file = await cgClient.files.getFile(file_id);
 
         if (file.status !== "completed") {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: JSON.stringify(
-                  {
-                    file_id: file_id,
-                    status: file.status,
-                    error: `Video is in ${file.status} status and metadata may be incomplete`,
-                    metadata: {
-                      filename: file.filename || null,
-                      uri: file.uri || null,
-                      created_at: file.created_at || null,
-                      updated_at: file.updated_at || null,
-                    },
-                  },
-                  null,
-                  2,
-                ),
-              },
-            ],
-          };
+          return jsonErrorResponse({
+            file_id: file_id,
+            status: file.status,
+            error: `Video is in ${file.status} status and metadata may be incomplete`,
+            metadata: {
+              filename: file.filename || null,
+              uri: file.uri || null,
+              created_at: file.created_at || null,
+              updated_at: file.updated_at || null,
+            },
+          });
         }
 
         // Comprehensive metadata response
@@ -114,22 +104,11 @@ export function registerGetVideoMetadata(
           ],
         };
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  file_id: file_id,
-                  error: `Failed to retrieve video metadata: ${error instanceof Error ? error.message : "Unknown error"}`,
-                  metadata: null,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return jsonErrorResponse({
+          file_id: file_id,
+          error: `Failed to retrieve video metadata: ${getErrorMessage(error)}`,
+          metadata: null,
+        });
       }
     },
   );

--- a/src/tools/retrieve-summaries.ts
+++ b/src/tools/retrieve-summaries.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Cloudglue } from "@cloudglue/cloudglue-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getErrorMessage, jsonErrorResponse } from "./error-response.js";
 
 export const schema = {
   collection_id: z
@@ -65,14 +66,7 @@ export function registerRetrieveSummaries(
         if (collection_type !== undefined && collection_type !== null) {
           errorObj.collection_type = collection_type;
         }
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(errorObj, null, 2),
-            },
-          ],
-        };
+        return jsonErrorResponse(errorObj);
       };
 
       // First get the collection to determine its type
@@ -81,7 +75,7 @@ export function registerRetrieveSummaries(
         collection = await cgClient.collections.getCollection(collection_id);
       } catch (error) {
         return formatErrorResponse(
-          `Error fetching collection: ${error instanceof Error ? error.message : "Unknown error"}`,
+          `Error fetching collection: ${getErrorMessage(error)}`,
         );
       }
 
@@ -120,7 +114,7 @@ export function registerRetrieveSummaries(
         }
       } catch (error) {
         return formatErrorResponse(
-          `Error fetching descriptions: ${error instanceof Error ? error.message : "Unknown error"}`,
+          `Error fetching descriptions: ${getErrorMessage(error)}`,
           collection.collection_type,
         );
       }

--- a/src/tools/search-video-moments.ts
+++ b/src/tools/search-video-moments.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Cloudglue } from "@cloudglue/cloudglue-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getErrorMessage, jsonErrorResponse } from "./error-response.js";
 
 export const schema = {
   collection_id: z
@@ -55,24 +56,13 @@ export function registerSearchVideoMoments(
           ],
         };
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(
-                {
-                  query: query,
-                  collection_id: collection_id,
-                  error: `Failed to search collection: ${error instanceof Error ? error.message : "Unknown error"}`,
-                  moments_found: null,
-                  citations: [],
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return jsonErrorResponse({
+          query: query,
+          collection_id: collection_id,
+          error: `Failed to search collection: ${getErrorMessage(error)}`,
+          moments_found: null,
+          citations: [],
+        });
       }
     },
   );

--- a/src/tools/search-video-summaries.ts
+++ b/src/tools/search-video-summaries.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Cloudglue } from "@cloudglue/cloudglue-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getErrorMessage, jsonErrorResponse } from "./error-response.js";
 
 export const schema = {
   collection_id: z
@@ -55,24 +56,13 @@ export function registerSearchVideoSummaries(
           ],
         };
       } catch (error) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(
-                {
-                  query: query,
-                  collection_id: collection_id,
-                  error: `Failed to search videos: ${error instanceof Error ? error.message : "Unknown error"}`,
-                  videos_found: null,
-                  total_results: 0,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return jsonErrorResponse({
+          query: query,
+          collection_id: collection_id,
+          error: `Failed to search videos: ${getErrorMessage(error)}`,
+          videos_found: null,
+          total_results: 0,
+        });
       }
     },
   );

--- a/src/tools/segment-video-camera-shots.ts
+++ b/src/tools/segment-video-camera-shots.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Cloudglue } from "@cloudglue/cloudglue-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getErrorMessage, jsonErrorResponse } from "./error-response.js";
 
 export const schema = {
   url: z
@@ -40,23 +41,12 @@ export function registerSegmentVideoCameraShots(
     async ({ url }) => {
       // Helper function to format error response
       const formatErrorResponse = (error: string) => {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  url: url,
-                  error: error,
-                  segments: null,
-                  total_shots: 0,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return jsonErrorResponse({
+          url: url,
+          error: error,
+          segments: null,
+          total_shots: 0,
+        });
       };
 
       // Check if it's a YouTube URL (not supported)
@@ -156,7 +146,7 @@ export function registerSegmentVideoCameraShots(
         );
       } catch (error) {
         return formatErrorResponse(
-          `Error creating camera shot segmentation: ${error instanceof Error ? error.message : "Unknown error"}`,
+          `Error creating camera shot segmentation: ${getErrorMessage(error)}`,
         );
       }
     },

--- a/src/tools/segment-video-chapters.ts
+++ b/src/tools/segment-video-chapters.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { Cloudglue } from "@cloudglue/cloudglue-js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getErrorMessage, jsonErrorResponse } from "./error-response.js";
 
 export const schema = {
   url: z
@@ -46,23 +47,12 @@ export function registerSegmentVideoChapters(
     async ({ url, prompt }) => {
       // Helper function to format error response
       const formatErrorResponse = (error: string) => {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  url: url,
-                  error: error,
-                  chapters: null,
-                  total_chapters: 0,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-        };
+        return jsonErrorResponse({
+          url: url,
+          error: error,
+          chapters: null,
+          total_chapters: 0,
+        });
       };
 
       // Step 1: Check for existing narrative segmentation jobs for this URL
@@ -80,7 +70,10 @@ export function registerSegmentVideoChapters(
           );
           if (fullJob.segments && fullJob.segments.length > 0) {
             const chapters = fullJob.segments.map(
-              (segment: { start_time: number; description?: string }, index: number) => ({
+              (
+                segment: { start_time: number; description?: string },
+                index: number,
+              ) => ({
                 chapter_number: index + 1,
                 start_time: segment.start_time,
                 start_time_formatted: formatTime(segment.start_time),
@@ -163,7 +156,7 @@ export function registerSegmentVideoChapters(
         );
       } catch (error) {
         return formatErrorResponse(
-          `Error creating chapter segmentation: ${error instanceof Error ? error.message : "Unknown error"}`,
+          `Error creating chapter segmentation: ${getErrorMessage(error)}`,
         );
       }
     },


### PR DESCRIPTION
## Summary
- add a shared MCP JSON error response helper that sets `isError: true` while preserving existing JSON payload shapes
- mark failed search, metadata, retrieval, describe, extraction, and segmentation paths as MCP errors
- leave intentional cache/list fallback paths as non-fatal so tools can still create jobs when a lookup misses

## Why
Several tools already returned JSON payloads with `error` fields, but the MCP result did not set `isError: true`. MCP clients can then treat failed searches, incomplete metadata, failed extractions, or segmentation errors as normal successful tool results. That makes agent/tool loops harder to reason about because a caller has to parse the text body to discover whether the tool actually failed.

This keeps the response body structure stable for existing clients while exposing failures through the MCP protocol-level error bit.

## Validation
- `npm ci --ignore-scripts`
- `npx prettier --check 'src/**/*.ts'`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error message consistency across video processing and analysis tools, including description generation, entity extraction, metadata retrieval, summaries, video moment search, and segmentation (camera shots and chapters). Error responses are now standardized across all operations to provide clearer and more consistent user feedback when issues occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudglue/cloudglue-mcp-server/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->