### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a Model Context Protocol (MCP) stdio server that bridges AI assistants to the hosted CloudGlue API. It is the runnable "application" here.
+
+- Package manager: **npm** (`package-lock.json` committed). `.npmrc` sets `ignore-scripts=true`. Dependencies are installed automatically by the environment update script.
+- Build/run commands are in `README.md` and `CLAUDE.md`. `npm run build` runs `tsc` then `mcpb pack` (outputs `build/` and a `.mcpb` bundle). There are **no test or lint scripts** — only `npm run format` (prettier).
+- Run the server over stdio with `node build/index.js --api-key <key>` (or set `CLOUDGLUE_API_KEY`). It prints `Cloudglue MCP Server running on stdio` on stderr.
+- The server **starts without a valid API key** and will answer MCP `initialize` / `tools/list` (10 tools registered), but any tool that actually calls CloudGlue needs a valid `CLOUDGLUE_API_KEY` and network access to `api.cloudglue.dev`.
+- It depends on `@cloudglue/cloudglue-js` from **npm** (the published package), not the local sibling `cloudglue-js` checkout.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `AGENTS.md` documenting how to set up and run this MCP server from a Cursor Cloud agent environment.

Key durable notes captured:
- Uses **npm** (`package-lock.json` committed); `.npmrc` sets `ignore-scripts=true`.
- `npm run build` runs `tsc` + `mcpb pack` (outputs `build/` and a `.mcpb` bundle). No test/lint scripts (only `npm run format`).
- Run over stdio: `node build/index.js --api-key <key>` (or `CLOUDGLUE_API_KEY`).
- Server **starts without a valid key** and answers MCP `initialize` / `tools/list` (10 tools); actual tool calls need a valid key + network to `api.cloudglue.dev`.
- Depends on `@cloudglue/cloudglue-js` from npm, not the local sibling checkout.

## Verification

- ✅ `npm install`
- ✅ `npm run build`
- ✅ Started server over stdio and listed all 10 tools via MCP `tools/list`

No source code changed; documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e368ecfd-21ad-4222-8776-4e440e84705d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e368ecfd-21ad-4222-8776-4e440e84705d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

